### PR TITLE
Refs CORE-5978

### DIFF
--- a/src/main/scala/com.socrata.geoexport/encoders/GeoJSONEncoder.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/GeoJSONEncoder.scala
@@ -1,0 +1,75 @@
+package com.socrata.geoexport.encoders
+
+import java.io.{OutputStream, OutputStreamWriter}
+
+import com.rojoma.json.v3.ast.{JObject, JString, JValue}
+import com.rojoma.json.v3.io.CompactJsonWriter
+import com.socrata.geoexport.intermediates.geojson.GeoJSONRepMapper
+
+import scala.language.{existentials, implicitConversions}
+import scala.util.{Failure, Success, Try}
+import geotypes._
+
+object GeoJSONMapper extends RowMapper[JValue] {
+
+  protected def prefix = """{
+      |  "type": "FeatureCollection",
+      |  "features": [
+    """.stripMargin
+
+  protected def suffix: String = """]
+    |}""".stripMargin
+
+  override protected def layerSuffix(moreLayers: Boolean) = {
+    if(moreLayers) {
+      // sigh...
+      "," // scalastyle:ignore multiple.string.literals
+    } else {
+      ""
+    }
+  }
+
+  protected def toRow(schema: Schema, fields: Fields): JValue = {
+
+    val (geomAttr, attrs) = splitOnGeo(GeoJSONRepMapper, schema, fields)
+
+    JObject(
+      Map(
+        "type" -> JString("Feature"),
+        "properties" -> JObject(attrs.flatMap { case (value, intermediary) =>
+          intermediary.toAttrNames.zip(GeoJSONRepMapper.toAttr((value, intermediary)))
+        }.toMap),
+        "geometry" -> GeoJSONRepMapper.toAttr(geomAttr).head
+      )
+    )
+  }
+
+  protected def writeRow(js: JValue, writer: OutputStreamWriter, moreFeatures: Boolean): Unit = {
+    var jsWriter = new CompactJsonWriter(writer)
+    jsWriter.write(js)
+    if(moreFeatures) writer.write(",")
+  }
+
+}
+
+
+
+object GeoJSONEncoder extends GeoEncoder {
+
+  def encode(layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
+    val writer = new OutputStreamWriter(outStream)
+    try {
+      GeoJSONMapper.serialize(layers, writer)
+      Success(outStream)
+    } catch {
+      case e: Exception => Failure(e)
+    } finally {
+      writer.close()
+    }
+  }
+
+  def encodes: Set[String] = Set("geojson")
+  def encodedMIME: String  = "application/vnd.geo+json"
+}
+
+

--- a/src/main/scala/com.socrata.geoexport/encoders/GeoTypes.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/GeoTypes.scala
@@ -1,0 +1,16 @@
+package com.socrata.geoexport.encoders
+
+import com.socrata.soql.SoQLPackIterator
+import com.socrata.soql.types._
+
+
+package geoexceptions {
+  case class MultipleGeometriesFoundException(message: String) extends Exception
+  case class UnknownGeometryException(message: String) extends Exception
+}
+
+package object geotypes {
+  type Layers = Iterable[SoQLPackIterator]
+  type Schema = Seq[(String, SoQLType)]
+  type Fields = Array[_ <: SoQLValue]
+}

--- a/src/main/scala/com.socrata.geoexport/encoders/KMZEncoder.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/KMZEncoder.scala
@@ -1,24 +1,14 @@
 package com.socrata.geoexport.encoders
 
-import java.io.{OutputStream, OutputStreamWriter, Writer}
-
-import com.rojoma.json.v3.ast.{JNumber, JString}
-import com.socrata.geoexport.encoders.KMLMapper._
-import com.socrata.soql.SoQLPackIterator
-import com.socrata.soql.types._
-import com.vividsolutions.jts.geom._
-import org.opengis.feature.`type`.AttributeDescriptor
-import org.slf4j.LoggerFactory
+import java.io.OutputStream
+import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.language.implicitConversions
-import scala.xml.{Node, XML}
-import com.rojoma.simplearm.util._
-import scala.util.{Try, Success, Failure}
-import java.util.zip.{ZipEntry, ZipOutputStream}
+import scala.util.{Failure, Success, Try}
+import geotypes._
 
 
 object KMZEncoder extends GeoEncoder {
-
 
   def encode(layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
     val zipStream = new ZipOutputStream(outStream)

--- a/src/main/scala/com.socrata.geoexport/encoders/RowMapper.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/RowMapper.scala
@@ -1,0 +1,55 @@
+package com.socrata.geoexport.encoders
+
+import java.io.{OutputStream, OutputStreamWriter, Writer}
+import com.socrata.soql.SoQLPackIterator
+import geoexceptions._
+import geotypes._
+import com.socrata.geoexport.intermediates.RepMapper
+import com.socrata.geoexport.intermediates.ShapeRep
+import com.socrata.soql.types._
+import scala.language.existentials
+
+trait RowMapper[T] {
+  type ValueRep = (_ <: SoQLValue, ShapeRep[_ <: SoQLValue])
+
+  def splitOnGeo(repMapper: RepMapper, schema: Schema, fields: Fields): (ValueRep, Seq[ValueRep]) = {
+    val (geoms, attrs) = schema
+      .zip(fields)
+      .map { case (column, value) => (value, ShapeRep.repFor(column, repMapper)) }
+      .partition { case (_value, intermediate) => intermediate.isGeometry }
+
+    val geomAttr = geoms match {
+      case Seq(g) => g
+      case _ => throw new MultipleGeometriesFoundException("Too many geometry columns!")
+    }
+
+    (geomAttr, attrs)
+  }
+
+  def serialize(layers: Layers, writer: OutputStreamWriter): Unit = {
+    writer.write(prefix)
+    // no scala. how about *you* avoid using null in the scala XML API
+    layers.zipWithIndex.foreach { case (layer, index) =>
+      toLayer(layer, writer, index < layers.size - 1)
+    }
+    writer.write(suffix)
+  }
+
+  def toLayer(layer: SoQLPackIterator, writer: OutputStreamWriter, moreLayers: Boolean): Unit = {
+    writer.write(layerPrefix)
+    layer.foreach { feature: Array[SoQLValue] =>
+      val row = toRow(layer.schema, feature)
+      writeRow(row, writer, layer.hasNext)
+    }
+    writer.write(layerSuffix(moreLayers))
+  }
+
+  protected def prefix: String
+  protected def suffix: String
+
+  protected def layerPrefix: String = ""
+  protected def layerSuffix(moreLayers: Boolean): String = ""
+
+  protected def toRow(schema: Schema, fields: Fields): T
+  protected def writeRow(thing: T, writer: OutputStreamWriter, moreFeatures: Boolean): Unit
+}

--- a/src/main/scala/com.socrata.geoexport/encoders/ShapefileEncoder.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/ShapefileEncoder.scala
@@ -25,13 +25,17 @@ import org.geotools.filter.identity.FeatureIdImpl
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
 import org.opengis.filter.Filter
-
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
+import geotypes._
 
 object ShapefileEncoder extends GeoEncoder {
+
+  lazy val log = LoggerFactory.getLogger(getClass)
+
   case class FeatureCollectionException(val message: String) extends Exception
 
   type SoQLColumn = (String, SoQLType)

--- a/src/main/scala/com.socrata.geoexport/encoders/intermediates/GeoJSON.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/intermediates/GeoJSON.scala
@@ -1,0 +1,183 @@
+package com.socrata.geoexport.intermediates.geojson
+
+import com.rojoma.json.v3.ast._
+import com.socrata.soql.types._
+import com.vividsolutions.jts.geom._
+import org.slf4j.LoggerFactory
+import com.socrata.geoexport.intermediates.{ShapeRep, RepMapper}
+import com.socrata.thirdparty.geojson.JtsCodecs.geoCodec
+
+
+case class GeoJSONTranslationException(message: String) extends Exception
+
+
+abstract class GeoJSONRep[T](soqlName: String) extends ShapeRep[T] {
+  protected def normalizeName(name: String) = name.replaceAll(":", "")
+
+  def toAttrBindings: Seq[Class[_]] = throw new GeoJSONTranslationException("geoJSON doesn't use bindings.")
+  def toAttrNames: Seq[String] = Seq(normalizeName(soqlName))
+}
+
+
+
+
+trait SimpleDatum {
+  def asSimpleData(item: String): Seq[JValue] = Seq(JString(item))
+  def toAttrNames: Seq[String]
+  def isGeometry: Boolean = false
+}
+
+
+trait GeoDatum {
+  def isGeometry: Boolean = true
+}
+
+
+class PointRep(soqlName: String) extends GeoJSONRep[SoQLPoint](soqlName) with GeoDatum {
+  def toAttrValues(soql: SoQLPoint): Seq[JValue] = soql match {
+    case SoQLPoint(p) => Seq(geoCodec.encode(p))
+  }
+}
+
+class MultiPointRep(soqlName: String) extends GeoJSONRep[SoQLMultiPoint](soqlName) with GeoDatum {
+  def toAttrValues(soql: SoQLMultiPoint): Seq[JValue] = soql match {
+    case SoQLMultiPoint(p) => Seq(geoCodec.encode(p))
+  }
+}
+
+class LineRep(soqlName: String) extends GeoJSONRep[SoQLLine](soqlName) with GeoDatum {
+  def toAttrValues(soql: SoQLLine): Seq[JValue] = soql match {
+    case SoQLLine(p) => Seq(geoCodec.encode(p))
+  }
+}
+
+class MultiLineRep(soqlName: String) extends GeoJSONRep[SoQLMultiLine](soqlName) with GeoDatum {
+  def toAttrValues(soql: SoQLMultiLine): Seq[JValue] = soql match {
+    case SoQLMultiLine(p) => Seq(geoCodec.encode(p))
+  }
+}
+
+class PolygonRep(soqlName: String) extends GeoJSONRep[SoQLPolygon](soqlName) with GeoDatum {
+  def toAttrValues(soql: SoQLPolygon): Seq[JValue] = soql match {
+    case SoQLPolygon(p) => Seq(geoCodec.encode(p))
+  }
+}
+
+class MultiPolygonRep(soqlName: String) extends GeoJSONRep[SoQLMultiPolygon](soqlName) with GeoDatum {
+  def toAttrValues(soql: SoQLMultiPolygon): Seq[JValue] = soql match {
+    case SoQLMultiPolygon(p) => Seq(geoCodec.encode(p))
+  }
+}
+
+class DateRep(soqlName: String) extends GeoJSONRep[SoQLDate](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLDate): Seq[JValue] = asSimpleData(SoQLDate.StringRep(soql.value))
+}
+
+class TimeRep(soqlName: String) extends GeoJSONRep[SoQLTime](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLTime): Seq[JValue] = asSimpleData(SoQLTime.StringRep(soql.value))
+}
+
+class FloatingTimestampRep(soqlName: String) extends GeoJSONRep[SoQLFloatingTimestamp](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLFloatingTimestamp): Seq[JValue] = asSimpleData(SoQLFloatingTimestamp.StringRep(soql.value))
+}
+
+class FixedTimestampRep(soqlName: String) extends GeoJSONRep[SoQLFixedTimestamp](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLFixedTimestamp): Seq[JValue] = asSimpleData(SoQLFixedTimestamp.StringRep(soql.value))
+}
+
+class NumberRep(soqlName: String) extends GeoJSONRep[SoQLNumber](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLNumber): Seq[JValue] = asSimpleData(soql.value.toString)
+}
+
+class TextRep(soqlName: String) extends GeoJSONRep[SoQLText](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLText): Seq[JValue] = asSimpleData(soql.value.toString)
+}
+
+class MoneyRep(soqlName: String) extends GeoJSONRep[SoQLMoney](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLMoney): Seq[JValue] = asSimpleData(soql.value.toString)
+}
+
+class BooleanRep(soqlName: String) extends GeoJSONRep[SoQLBoolean](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLBoolean): Seq[JValue] = asSimpleData(soql.value.toString)
+}
+
+class VersionRep(soqlName: String) extends GeoJSONRep[SoQLVersion](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLVersion): Seq[JValue] = asSimpleData(soql.value.toString)
+}
+
+class IDRep(soqlName: String) extends GeoJSONRep[SoQLID](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLID): Seq[JValue] = asSimpleData(soql.value.toString)
+}
+
+class DoubleRep(soqlName: String) extends GeoJSONRep[SoQLDouble](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLDouble): Seq[JValue] = asSimpleData(soql.value.toString)
+}
+
+class ArrayRep(soqlName: String) extends GeoJSONRep[SoQLArray](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLArray): Seq[JValue] = Seq(soql.value)
+}
+
+class JSONRep(soqlName: String) extends GeoJSONRep[SoQLJson](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLJson): Seq[JValue] = Seq(soql.value)
+}
+
+class ObjectRep(soqlName: String) extends GeoJSONRep[SoQLObject](soqlName) with SimpleDatum {
+  def toAttrValues(soql: SoQLObject): Seq[JValue] = Seq(soql.value)
+}
+
+/**
+  Maps all the SoQLColumns to intermediate columns
+*/
+object GeoJSONRepMapper extends RepMapper {
+  lazy val log = LoggerFactory.getLogger(getClass)
+
+  def forPoint(name: String): PointRep =                          new PointRep(name)
+  def forMultiPoint(name: String): MultiPointRep =                new MultiPointRep(name)
+  def forLine(name: String): LineRep =                            new LineRep(name)
+  def forMultiLine(name: String): MultiLineRep =                  new MultiLineRep(name)
+  def forPolygon(name: String): PolygonRep =                      new PolygonRep(name)
+  def forMultiPolygon(name: String): MultiPolygonRep =            new MultiPolygonRep(name)
+  def forDate(name: String): DateRep =                            new DateRep(name)
+  def forTime(name: String): TimeRep =                            new TimeRep(name)
+  def forFloatingTimestamp(name: String): FloatingTimestampRep =  new FloatingTimestampRep(name)
+  def forFixedTimestamp(name: String): FixedTimestampRep =        new FixedTimestampRep(name)
+  def forNumber(name: String): NumberRep =                        new NumberRep(name)
+  def forText(name: String): TextRep =                            new TextRep(name)
+  def forMoney(name: String): MoneyRep =                          new MoneyRep(name)
+  def forBoolean(name: String): BooleanRep =                      new BooleanRep(name)
+  def forVersion(name: String): VersionRep =                      new VersionRep(name)
+  def forID(name: String): IDRep =                                new IDRep(name)
+  def forArray(name: String): ArrayRep =                          new ArrayRep(name)
+  def forDouble(name: String): DoubleRep =                        new DoubleRep(name)
+  def forJson(name: String): JSONRep =                            new JSONRep(name)
+  def forObject(name: String): ObjectRep =                        new ObjectRep(name)
+  // scalastyle:off cyclomatic.complexity
+  def toAttr(thing: (SoQLValue, ShapeRep[_ <: SoQLValue])) : Seq[JValue] = thing match {
+    case (value: SoQLPoint, intermediary: PointRep) => intermediary.toAttrValues(value)
+    case (value: SoQLMultiPoint, intermediary: MultiPointRep) => intermediary.toAttrValues(value)
+    case (value: SoQLLine, intermediary: LineRep) => intermediary.toAttrValues(value)
+    case (value: SoQLMultiLine, intermediary: MultiLineRep) => intermediary.toAttrValues(value)
+    case (value: SoQLPolygon, intermediary: PolygonRep) => intermediary.toAttrValues(value)
+    case (value: SoQLMultiPolygon, intermediary: MultiPolygonRep) => intermediary.toAttrValues(value)
+    case (value: SoQLDate, intermediary: DateRep) => intermediary.toAttrValues(value)
+    case (value: SoQLTime, intermediary: TimeRep) => intermediary.toAttrValues(value)
+    case (value: SoQLFloatingTimestamp, intermediary: FloatingTimestampRep) => intermediary.toAttrValues(value)
+    case (value: SoQLFixedTimestamp, intermediary: FixedTimestampRep) => intermediary.toAttrValues(value)
+    case (value: SoQLNumber, intermediary: NumberRep) => intermediary.toAttrValues(value)
+    case (value: SoQLText, intermediary: TextRep) => intermediary.toAttrValues(value)
+    case (value: SoQLMoney, intermediary: MoneyRep) => intermediary.toAttrValues(value)
+    case (value: SoQLBoolean, intermediary: BooleanRep) => intermediary.toAttrValues(value)
+    case (value: SoQLVersion, intermediary: VersionRep) => intermediary.toAttrValues(value)
+    case (value: SoQLID, intermediary: IDRep) => intermediary.toAttrValues(value)
+    case (value: SoQLArray, intermediary: ArrayRep) => intermediary.toAttrValues(value)
+    case (value: SoQLDouble, intermediary: DoubleRep) => intermediary.toAttrValues(value)
+    case (value: SoQLJson, intermediary: JSONRep) => intermediary.toAttrValues(value)
+    case (value: SoQLObject, intermediary: ObjectRep) => intermediary.toAttrValues(value)
+    case (SoQLNull, _) => Seq(null) // scalastyle:ignore null
+    case (value: SoQLValue, _) =>
+      log.error(s"Unknown SoQLValue: ${value.getClass()} - coercing toString but you should fix this!")
+      Seq(JString(value.toString))
+  }
+  // scalastyle:on cyclomatic.complexity
+}
+

--- a/src/main/scala/com.socrata.geoexport/encoders/intermediates/ShapeRep.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/intermediates/ShapeRep.scala
@@ -12,7 +12,7 @@ import org.joda.time.format.DateTimeFormat
   for each SoQLType which will translate names/values to those representable
   by the export format
 
-  RepMapper is a gross workaround for the lack of dependents typing i guess.
+  RepMapper is a gross workaround for the lack of dependent typing i guess.
 */
 
 case class UnknownSoQLTypeException(message: String) extends Exception

--- a/src/main/scala/com.socrata.geoexport/http/ExportService.scala
+++ b/src/main/scala/com.socrata.geoexport/http/ExportService.scala
@@ -10,7 +10,7 @@ import com.rojoma.json.v3.io.JsonReader
 import com.rojoma.json.v3.util.JsonUtil
 import com.socrata.geoexport.UnmanagedCuratedServiceClient
 import com.socrata.geoexport.conversions.Converter
-import com.socrata.geoexport.encoders.{KMLEncoder, ShapefileEncoder, KMZEncoder}
+import com.socrata.geoexport.encoders.{KMLEncoder, ShapefileEncoder, KMZEncoder, GeoJSONEncoder}
 import com.socrata.geoexport.http.ExportService._
 import com.socrata.http.client.{RequestBuilder, Response}
 import com.socrata.http.server.responses.{Json, _}
@@ -33,7 +33,7 @@ object ExportService {
   // to appease the scala linter.. ಠ_ಠ
   val errorKey = "reason"
   val FourbyFour = "[\\w0-9]{4}-[\\w0-9]{4}"
-  val encoders = List(KMLEncoder, ShapefileEncoder, KMZEncoder)
+  val encoders = List(KMLEncoder, ShapefileEncoder, KMZEncoder, GeoJSONEncoder)
   val formats: Set[String] = encoders.flatMap(_.encodes).toSet
   type LayerFailure = (Int, JValue)
 

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/GeoJSONTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/GeoJSONTest.scala
@@ -1,0 +1,313 @@
+package com.socrata.geoexport
+
+import java.io._
+import java.math.BigDecimal
+import java.net.URL
+import java.util.{Date, UUID}
+import java.util.zip.{ZipEntry, ZipFile}
+import com.rojoma.json.v3.ast._
+import com.rojoma.json.v3.io.JsonReader
+import com.rojoma.json.v3.util.JsonUtil
+import com.socrata.soql.types._
+import com.vividsolutions.jts.geom._
+import org.apache.commons.io.IOUtils
+import org.geotools.data.shapefile.ShapefileDataStore
+import org.geotools.data.simple.{SimpleFeatureIterator, SimpleFeatureSource, SimpleFeatureCollection}
+import org.joda.time.{DateTimeZone, LocalTime, LocalDateTime, DateTime}
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import scala.util.{Try, Success, Failure}
+import scala.xml.Utility.{trim => xmltrim}
+import com.socrata.geoexport.conversions.Converter
+import org.apache.commons.io.output.ByteArrayOutputStream
+import com.rojoma.json.v3.io.CompactJsonWriter
+import com.socrata.geoexport.encoders.GeoJSONEncoder
+import scala.collection.JavaConversions._;
+import com.socrata.thirdparty.geojson.JtsCodecs.geoCodec
+
+
+class GeoJSONTest extends TestBase {
+  val ldt = LocalDateTime.parse("2015-03-22T01:23")
+  val dt = DateTime.parse("2015-03-22T12:00:00-08:00")
+  val THE_TIME_UTC = 1427025600000L
+  val AN_HOUR = 60 * 60 * 1000
+
+  val simpleSchema = List(
+    ("a_name", SoQLText),
+    ("a_number", SoQLNumber),
+    ("a_bool", SoQLBoolean),
+    (":a_ts", SoQLFixedTimestamp),
+    (":a_fts", SoQLFloatingTimestamp),
+    ("a_time", SoQLTime),
+    (":a_date", SoQLDate),
+    (":a_money", SoQLMoney),
+    (":an_id", SoQLID),
+    (":a_version", SoQLVersion),
+    ("a_double", SoQLDouble),
+    ("a_num_arr", SoQLArray),
+    ("a_str_arr", SoQLArray),
+    ("a_json", SoQLJson),
+    ("an_object", SoQLObject)
+  )
+
+  val simpleRows = List(
+    SoQLText("this is a name"),
+    SoQLNumber(new BigDecimal(42.00)),
+    SoQLBoolean(true),
+    SoQLFixedTimestamp(dt),
+    SoQLFloatingTimestamp(ldt.plusHours(1)),
+    SoQLTime(ldt.toLocalTime),
+    SoQLDate(ldt.toLocalDate),
+    SoQLMoney((new BigDecimal(42.00))),
+    SoQLID(42),
+    SoQLVersion(32),
+    SoQLDouble(42.00),
+    SoQLArray(JArray(Seq(JNumber(1), JNumber(2), JNumber(3)))),
+    SoQLArray(JArray(Seq(JString("a"), JString("b"), JString("c")))),
+    SoQLJson(JsonReader.fromString("""{"something": "else", "a_json_number": 1, "nested": {"child": "hello"}}""")),
+    SoQLObject(JsonReader.fromString("""{"something": "wow", "an_object_number": 7, "nested": {"child": "hi"}}""").asInstanceOf[JObject])
+
+  )
+
+
+  private def convertGeoJSON(layers: List[InputStream]): String = {
+    val outStream = new ByteArrayOutputStream()
+    val result = Converter.execute(layers, GeoJSONEncoder, outStream) match {
+      case Success(outstream) =>
+        outStream.flush()
+        outStream.toString("UTF-8")
+      case Failure(err) => throw err
+    }
+    result.replaceAll("\\s", "")
+  }
+
+  private def getExpected(shape: String): String = {
+    s"""
+    {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {
+            "a_money": "42",
+            "a_str_arr": [
+              "a",
+              "b",
+              "c"
+            ],
+            "a_name": "this is a name",
+            "a_date": "2015-03-22",
+            "an_object": {
+              "something": "wow",
+              "an_object_number": 7,
+              "nested": {
+                "child": "hi"
+              }
+            },
+            "an_id": "42",
+            "a_num_arr": [
+              1,
+              2,
+              3
+            ],
+            "a_version": "32",
+            "a_json": {
+              "something": "else",
+              "a_json_number": 1,
+              "nested": {
+                "child": "hello"
+              }
+            },
+            "a_number": "42",
+            "a_ts": "2015-03-22T20:00:00.000Z",
+            "a_fts": "2015-03-22T02:23:00.000",
+            "a_double": "42.0",
+            "a_bool": "true",
+            "a_time": "01:23:00.000"
+          },
+          "geometry": ${shape}
+        }
+      ]
+    }
+    """.replaceAll("\\s", "")
+  }
+
+  private def serializeSingleLayer(name: String, geom: Geometry, soqlValue: SoQLValue, kind: SoQLType) : String = {
+
+    val soqlSchema = simpleSchema :+ ((name, kind))
+    val items = simpleRows :+ soqlValue
+    val packed = pack(soqlSchema, List(items.toArray))
+
+    val layers = List(packed)
+    convertGeoJSON(layers)
+  }
+
+  test("can convert a stream of a point soqlpack to geoJSON") {
+    val p = wkt("POINT (0 1)").asInstanceOf[Point]
+    val actual = serializeSingleLayer("a_point", p, SoQLPoint(p), SoQLPoint)
+
+    val expectedJs = CompactJsonWriter.toString(geoCodec.encode(p))
+    actual must be(getExpected(expectedJs))
+  }
+
+  test("can convert a stream of line soqlpack to geoJSON") {
+    val p = wkt("LINESTRING (30 10, 10 30, 40 40)").asInstanceOf[LineString]
+    val actual = serializeSingleLayer("a_line", p, SoQLLine(p), SoQLLine)
+
+    val expectedJs = CompactJsonWriter.toString(geoCodec.encode(p))
+    actual must be(getExpected(expectedJs))
+  }
+
+  test("can convert a stream of polygon soqlpack to geoJSON") {
+    val p = wkt("POLYGON ((30.0 10, 40 40, 20 40, 10 20, 30 10))").asInstanceOf[Polygon]
+    val actual = serializeSingleLayer("a_poly", p, SoQLPolygon(p), SoQLPolygon)
+
+    val expectedJs = CompactJsonWriter.toString(geoCodec.encode(p))
+    actual must be(getExpected(expectedJs))
+
+    //with donuts (yum)
+    val donut = wkt("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))").asInstanceOf[Polygon]
+    val actualDonut = serializeSingleLayer("a_poly", donut, SoQLPolygon(donut), SoQLPolygon)
+    val expectedDonut = CompactJsonWriter.toString(geoCodec.encode(donut))
+    actualDonut must be(getExpected(expectedDonut))
+
+  }
+
+  test("can convert a stream of multipoint soqlpack to geoJSON") {
+    val p = wkt("MULTIPOINT ((10 40), (40 30), (20 20), (30 10))").asInstanceOf[MultiPoint]
+    val actual = serializeSingleLayer("a_multipoint", p, SoQLMultiPoint(p), SoQLMultiPoint)
+
+    val expectedJs = CompactJsonWriter.toString(geoCodec.encode(p))
+    actual must be(getExpected(expectedJs))
+  }
+
+  test("can convert a stream of multiline soqlpack to geoJSON") {
+    val p = wkt("MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))").asInstanceOf[MultiLineString]
+    val actual = serializeSingleLayer("a_multiline", p, SoQLMultiLine(p), SoQLMultiLine)
+
+    val expectedJs = CompactJsonWriter.toString(geoCodec.encode(p))
+    actual must be(getExpected(expectedJs))
+  }
+
+
+  test("can convert a stream of multipolygon soqlpack to geoJSON") {
+    val p = wkt("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))").asInstanceOf[MultiPolygon]
+    val actual = serializeSingleLayer("a_multipoly", p, SoQLMultiPolygon(p), SoQLMultiPolygon)
+
+    val expectedJs = CompactJsonWriter.toString(geoCodec.encode(p))
+    actual must be(getExpected(expectedJs))
+  }
+
+  test("can convert a stream of heterogenous layers to geoJSON") {
+    val line = wkt("LINESTRING (30 10, 10 30, 40 40)").asInstanceOf[LineString]
+    val poly = wkt("POLYGON ((30.0 10, 40 40, 20 40, 10 20, 30 10))").asInstanceOf[Polygon]
+
+    val lineSchema = simpleSchema :+ (("a_line", SoQLLine))
+    val polySchema = simpleSchema :+ (("a_poly", SoQLPolygon))
+    val lineItems = simpleRows :+ SoQLLine(line)
+    val polyItems = simpleRows :+ SoQLPolygon(poly)
+
+    val layerOnePack = pack(lineSchema, List(lineItems.toArray))
+    val layerTwoPack = pack(polySchema, List(polyItems.toArray))
+
+    val layers = List(layerOnePack, layerTwoPack)
+    val actual = convertGeoJSON(layers)
+
+    val expectedLine = geoCodec.encode(line)
+    val expectedPoly = geoCodec.encode(poly)
+
+    val expectedJs = s"""
+    {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {
+            "a_money": "42",
+            "a_str_arr": [
+              "a",
+              "b",
+              "c"
+            ],
+            "a_name": "this is a name",
+            "a_date": "2015-03-22",
+            "an_object": {
+              "something": "wow",
+              "an_object_number": 7,
+              "nested": {
+                "child": "hi"
+              }
+            },
+            "an_id": "42",
+            "a_num_arr": [
+              1,
+              2,
+              3
+            ],
+            "a_version": "32",
+            "a_json": {
+              "something": "else",
+              "a_json_number": 1,
+              "nested": {
+                "child": "hello"
+              }
+            },
+            "a_number": "42",
+            "a_ts": "2015-03-22T20:00:00.000Z",
+            "a_fts": "2015-03-22T02:23:00.000",
+            "a_double": "42.0",
+            "a_bool": "true",
+            "a_time": "01:23:00.000"
+          },
+          "geometry": ${expectedLine}
+        },
+        {
+          "type": "Feature",
+          "properties": {
+            "a_money": "42",
+            "a_str_arr": [
+              "a",
+              "b",
+              "c"
+            ],
+            "a_name": "this is a name",
+            "a_date": "2015-03-22",
+            "an_object": {
+              "something": "wow",
+              "an_object_number": 7,
+              "nested": {
+                "child": "hi"
+              }
+            },
+            "an_id": "42",
+            "a_num_arr": [
+              1,
+              2,
+              3
+            ],
+            "a_version": "32",
+            "a_json": {
+              "something": "else",
+              "a_json_number": 1,
+              "nested": {
+                "child": "hello"
+              }
+            },
+            "a_number": "42",
+            "a_ts": "2015-03-22T20:00:00.000Z",
+            "a_fts": "2015-03-22T02:23:00.000",
+            "a_double": "42.0",
+            "a_bool": "true",
+            "a_time": "01:23:00.000"
+          },
+          "geometry": ${expectedPoly}
+        }
+      ]
+    }
+    """.replaceAll("\\s", "")
+    println(actual)
+
+    actual must be(expectedJs)
+
+  }
+
+}

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/KMLIshTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/KMLIshTest.scala
@@ -159,7 +159,7 @@ class KMLIshTest extends TestBase {
   }
 
   protected def testLinestring(convert: List[DataInputStream] => Node) = {
-        val p = wkt("LINESTRING (30 10, 10 30, 40 40)").asInstanceOf[LineString]
+    val p = wkt("LINESTRING (30 10, 10 30, 40 40)").asInstanceOf[LineString]
 
     val schema = simpleSchema :+ (("a_line", SoQLLine))
     val items = simpleRows :+ SoQLLine(p)

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/KMLTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/KMLTest.scala
@@ -4,6 +4,7 @@ package com.socrata.geoexport
 import com.socrata.geoexport.encoders.KMLMapper._
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom._
+import encoders.geoexceptions._
 
 import scala.xml.Utility.{trim => xmltrim}
 

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/KMZTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/KMZTest.scala
@@ -4,7 +4,7 @@ package com.socrata.geoexport
 import com.socrata.geoexport.encoders.KMLMapper._
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom._
-
+import encoders.geoexceptions._
 import scala.xml.Utility.{trim => xmltrim}
 
 class KMZTest extends KMLIshTest {


### PR DESCRIPTION
* export stuff as geoJSON
* clean up KML encoder to be the same as geoJSON, they follow the same pattern now
* shapefile is still a special snowflake
* add geojson tests
* add new intermediate representations for geoJSON, bringing the verbosity level > 9000