### PR TITLE
Fixes header/row length out of sync bug

### DIFF
--- a/src/main/scala/com.socrata.geoexport/encoders/intermediates/Shapefile.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/intermediates/Shapefile.scala
@@ -229,7 +229,7 @@ object ShapefileRepMapper extends RepMapper {
     case (value: SoQLDouble, intermediary: DoubleRep) => intermediary.toAttrValues(value)
     case (value: SoQLJson, intermediary: JSONRep) => intermediary.toAttrValues(value)
     case (value: SoQLObject, intermediary: ObjectRep) => intermediary.toAttrValues(value)
-    case (SoQLNull, _) => Seq(null) // scalastyle:ignore null
+    case (SoQLNull, intermediary) => intermediary.toAttrNames.map{ _name => null} // scalastyle:ignore null
     case (value: SoQLValue, _) =>
       log.error(s"Unknown SoQLValue: ${value.getClass()} - coercing toString but you should fix this!")
       Seq(value.toString: java.lang.String)

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/ShapefileTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/ShapefileTest.scala
@@ -42,6 +42,7 @@ class ShapefileTest extends TestBase {
     ("a_bool", SoQLBoolean),
     (":a_ts", SoQLFixedTimestamp),
     (":a_fts", SoQLFloatingTimestamp),
+    ("a_null_fts", SoQLFloatingTimestamp),
     ("a_time", SoQLTime),
     (":a_date", SoQLDate),
     (":a_money", SoQLMoney),
@@ -60,6 +61,7 @@ class ShapefileTest extends TestBase {
     SoQLBoolean(true),
     SoQLFixedTimestamp(dt),
     SoQLFloatingTimestamp(ldt.plusHours(1)),
+    SoQLNull,
     SoQLTime(ldt.toLocalTime),
     SoQLDate(ldt.toLocalDate),
     SoQLMoney((new BigDecimal(42.00))),
@@ -99,6 +101,9 @@ class ShapefileTest extends TestBase {
 
     feature.getAttribute("date_a_ts").asInstanceOf[Date] must be(ldt.withTime(0, 0, 0, 0).toDate)
     feature.getAttribute("time_a_ts") must be("20:00:00.000")
+
+    feature.getAttribute("date_a_nul") must be(null)
+    feature.getAttribute("time_a_nul") must be(null)
 
     feature.getAttribute("date_a_fts").asInstanceOf[Date] must be(ldt.withTime(0, 0, 0, 0).toDate)
     feature.getAttribute("time_a_fts") must be("02:23:00.000")


### PR DESCRIPTION
* in shapefiles, DateTime gets split into multiple columns.
  When they're null, they are a SoQLNull, but the SoQLNull
  was not being split to match the split in the header
  based on the type, which caused geotools to crash.