### PR TITLE
Make encoders take a resource scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.mockito"              % "mockito-core"             % "1.10.19" % "test",
-  "org.scalacheck"          %% "scalacheck"               % "1.11.6" % "test"
+  "org.scalacheck"          %% "scalacheck"               % "1.11.6" % "test",
+  "com.socrata"             %% "socrata-test-common"      % "0.2.8" % "test"
 )
 
 val TestOptionNoTraces = "-oD"

--- a/src/main/scala/com.socrata.geoexport/conversions/Converter.scala
+++ b/src/main/scala/com.socrata.geoexport/conversions/Converter.scala
@@ -6,6 +6,7 @@ import com.socrata.geoexport.encoders.GeoEncoder
 import com.socrata.soql.SoQLPackIterator
 
 import scala.util.{Failure, Success, Try}
+import com.rojoma.simplearm.v2.ResourceScope
 
 object Converter {
 
@@ -14,11 +15,11 @@ object Converter {
     This will merge the layers into whatever representation the encoder decides to represent
     layers as.
   */
-  def execute(layerStreams: Iterable[InputStream], encoder: GeoEncoder, os: OutputStream) : Try[OutputStream] = {
+  def execute(rs: ResourceScope, layerStreams: Iterable[InputStream], encoder: GeoEncoder, os: OutputStream) : Try[OutputStream] = {
     Try(layerStreams.map { is =>
       new SoQLPackIterator(new DataInputStream(is))
     }).flatMap { features =>
-      encoder.encode(features, os)
+      encoder.encode(rs, features, os)
     }
   }
 }

--- a/src/main/scala/com.socrata.geoexport/encoders/GeoEncoder.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/GeoEncoder.scala
@@ -2,11 +2,12 @@ package com.socrata.geoexport.encoders
 
 import java.io.OutputStream
 
+import com.rojoma.simplearm.v2.ResourceScope
 import com.socrata.soql.SoQLPackIterator
 import scala.util.Try
 
 trait GeoEncoder {
-  def encode(layers: Iterable[SoQLPackIterator], outStream: OutputStream) : Try[OutputStream]
+  def encode(rs: ResourceScope, layers: Iterable[SoQLPackIterator], outStream: OutputStream) : Try[OutputStream]
   def encodes: Set[String]
   def encodedMIME: String
 }

--- a/src/main/scala/com.socrata.geoexport/encoders/GeoJSONEncoder.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/GeoJSONEncoder.scala
@@ -5,7 +5,7 @@ import java.io.{OutputStream, OutputStreamWriter}
 import com.rojoma.json.v3.ast.{JObject, JString, JValue}
 import com.rojoma.json.v3.io.CompactJsonWriter
 import com.socrata.geoexport.intermediates.geojson.GeoJSONRepMapper
-
+import com.rojoma.simplearm.v2.ResourceScope
 import scala.language.{existentials, implicitConversions}
 import scala.util.{Failure, Success, Try}
 import geotypes._
@@ -56,7 +56,7 @@ object GeoJSONMapper extends RowMapper[JValue] {
 
 object GeoJSONEncoder extends GeoEncoder {
 
-  def encode(layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
+  def encode(rs: ResourceScope, layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
     val writer = new OutputStreamWriter(outStream)
     try {
       GeoJSONMapper.serialize(layers, writer)

--- a/src/main/scala/com.socrata.geoexport/encoders/KMLEncoder.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/KMLEncoder.scala
@@ -3,7 +3,7 @@ package com.socrata.geoexport.encoders
 import java.io.{OutputStream, OutputStreamWriter}
 
 import com.socrata.geoexport.intermediates.kml._
-
+import com.rojoma.simplearm.v2.ResourceScope
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 import scala.xml.{Node, XML}
@@ -53,7 +53,7 @@ object KMLMapper extends RowMapper[Node] {
 }
 
 object KMLEncoder extends GeoEncoder {
-  def encode(layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
+  def encode(rs: ResourceScope, layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
     val writer = new OutputStreamWriter(outStream)
     try {
       KMLMapper.serialize(layers, writer)

--- a/src/main/scala/com.socrata.geoexport/encoders/KMZEncoder.scala
+++ b/src/main/scala/com.socrata.geoexport/encoders/KMZEncoder.scala
@@ -2,7 +2,7 @@ package com.socrata.geoexport.encoders
 
 import java.io.OutputStream
 import java.util.zip.{ZipEntry, ZipOutputStream}
-
+import com.rojoma.simplearm.v2.ResourceScope
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 import geotypes._
@@ -10,11 +10,11 @@ import geotypes._
 
 object KMZEncoder extends GeoEncoder {
 
-  def encode(layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
+  def encode(rs: ResourceScope, layers: Layers, outStream: OutputStream) : Try[OutputStream] = {
     val zipStream = new ZipOutputStream(outStream)
     val entry = new ZipEntry("export.kml")
     zipStream.putNextEntry(entry)
-    KMLEncoder.encode(layers, zipStream) match {
+    KMLEncoder.encode(rs, layers, zipStream) match {
       case Success(_) => Success(zipStream)
       case Failure(reason) => Failure(reason)
     }

--- a/src/main/scala/com.socrata.geoexport/http/ExportService.scala
+++ b/src/main/scala/com.socrata.geoexport/http/ExportService.scala
@@ -127,7 +127,7 @@ class ExportService(sodaClient: UnmanagedCuratedServiceClient) extends SimpleRes
             OK ~> ContentType(encoder.encodedMIME) ~> Stream({out: OutputStream =>
 
               val streams = responses.map { r => r.inputStream() }
-              Converter.execute(streams, encoder, out) match {
+              Converter.execute(req.resourceScope, streams, encoder, out) match {
                 case Success(s) =>
                   out.flush()
                   log.info(s"Finished writing export for ${fxfs}")

--- a/src/test/scala/com.socrata.geoexport/TestBase.scala
+++ b/src/test/scala/com.socrata.geoexport/TestBase.scala
@@ -17,12 +17,14 @@ import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 import org.velvia.MsgPack
 import scala.util.{Try, Success, Failure}
+import com.socrata.test.common.UnusedSugarCommon
 
 trait TestBase
     extends FunSuite
     with org.scalatest.MustMatchers
     with PropertyChecks
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with UnusedSugarCommon {
 
   def wkt(w: String): Geometry = {
     val pm = new PrecisionModel(PrecisionModel.FIXED)

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/GeoJSONTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/GeoJSONTest.scala
@@ -71,7 +71,7 @@ class GeoJSONTest extends TestBase {
 
   private def convertGeoJSON(layers: List[InputStream]): String = {
     val outStream = new ByteArrayOutputStream()
-    val result = Converter.execute(layers, GeoJSONEncoder, outStream) match {
+    val result = Converter.execute(Unused, layers, GeoJSONEncoder, outStream) match {
       case Success(outstream) =>
         outStream.flush()
         outStream.toString("UTF-8")

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/KMLIshTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/KMLIshTest.scala
@@ -70,7 +70,7 @@ class KMLIshTest extends TestBase {
 
   protected def convertKML(layers: List[InputStream]): Node = {
     val outStream = new ByteArrayOutputStream()
-    val result = Converter.execute(layers, KMLEncoder, outStream) match {
+    val result = Converter.execute(Unused, layers, KMLEncoder, outStream) match {
       case Success(outstream) =>
         outStream.flush()
         outStream.toString("UTF-8")
@@ -80,7 +80,7 @@ class KMLIshTest extends TestBase {
   }
   protected def convertKMZ(layers: List[InputStream]): Node = {
     val outStream = new ByteArrayOutputStream()
-    val result = Converter.execute(layers, KMZEncoder, outStream) match {
+    val result = Converter.execute(Unused, layers, KMZEncoder, outStream) match {
       case Success(outstream) =>
         outStream.flush()
         val zis = new ZipInputStream(new ByteArrayInputStream(outStream.toByteArray))

--- a/src/test/scala/com.socrata.geoexport/convert/encodings/ShapefileTest.scala
+++ b/src/test/scala/com.socrata.geoexport/convert/encodings/ShapefileTest.scala
@@ -78,7 +78,7 @@ class ShapefileTest extends TestBase {
   private def convertShapefile(layers: List[InputStream]): File = {
     val archive = new File(s"/tmp/test_geo_export_${UUID.randomUUID()}.zip")
     val outStream = new FileOutputStream(archive)
-    Converter.execute(layers, ShapefileEncoder, outStream) match {
+    Converter.execute(Unused, layers, ShapefileEncoder, outStream) match {
       case Success(outstream) =>
         outStream.flush()
         archive


### PR DESCRIPTION
* streams now are allocated through rs, which should clean them up
* updated tests