### PR TITLE
EN-12680 : downgrade apache curator from previous bump back to zk compatible version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
 
   "commons-codec"            % "commons-codec"            % "1.10",
   "commons-io"               % "commons-io"               % "2.4",
-  "org.apache.curator"       % "curator-x-discovery"      % "4.1.0",
+  "org.apache.curator"       % "curator-x-discovery"      % "2.7.0",
   "com.socrata"             %% "soql-pack"                % "2.11.7",
 
   "org.geotools"             % "gt-shapefile"             % "14.0"

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ libraryDependencies ++= Seq(
 
   "commons-codec"            % "commons-codec"            % "1.10",
   "commons-io"               % "commons-io"               % "2.4",
+  // curator versions in the 4.x range are incompatible with our current zk version 3.4.14
   "org.apache.curator"       % "curator-x-discovery"      % "2.7.0",
   "com.socrata"             %% "soql-pack"                % "2.11.7",
 


### PR DESCRIPTION
turns out that bumping the org.apache.curator library to 4.x is not in fact compatible with the version of zk we current run (3.4.14).  So we are dropping it back to LKG version and will investigate upgrade paths.