### PR TITLE
Return 4XX reponse if geotools hits ulimit

### DIFF
--- a/src/main/scala/com.socrata.geoexport/http/ExportService.scala
+++ b/src/main/scala/com.socrata.geoexport/http/ExportService.scala
@@ -156,7 +156,7 @@ class ExportService(sodaClient: UnmanagedCuratedServiceClient) extends SimpleRes
                     log.info(s"Finished writing export for ${fxfs}")
                   })
                 } catch {
-                  case e: Exception => {
+                  case e: IOException => {
                     log.error("Error exporting shapefile", e)
                     NotAcceptable
                   }


### PR DESCRIPTION
The shapefile encoder works by creating temporary files, letting
geotools write features to them, then streaming them as a zipfile to
the client. For large datasets, this eats up a lot of disk. Because of
this and because the shapefile format only supports files <= 2GB, we
put a ulimit on the disk this process can use. When we hit that
ulimit when geotools is writing ot the temp files, we were returning
200 and exporting a 0-byte shapefile. This change splits out the
writing step from the streaming step so that if writing fails, we can
return an error response instead.