### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,4 @@ doesn't need to be related in any way, they just need to have one shape column.
 
 To tag a release to be built and deployed to RC:
 
-1. Create a branch from main and run `sbt release`.
-1. Follow the prompts to bump the version, which will create two commits.
-1. Create a PR and get it merged to main.
+1. On main, run `sbt release`. This will create two commits to bump the version and create a git tag for the release version and then push them to the remote repo.


### PR DESCRIPTION
The instructions for releasing did not work as anticipated. This commit reverts the instructions to use the previous method.